### PR TITLE
Release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@coinbase/staking-client-library-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Coinbase Cloud Staking API Typescript Library",
+  "repository": "https://github.com/coinbase/staking-client-library-ts.git",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Add back repository URL in package.json to fix npm publish with provenance related issue by @drohit-cb 