### PR TITLE
Swap Proto Gen To BSR

### DIFF
--- a/docs/openapi/orchestration.swagger.json
+++ b/docs/openapi/orchestration.swagger.json
@@ -189,6 +189,160 @@
         ]
       }
     },
+    "/v1/workflows": {
+      "get": {
+        "summary": "List supported workflows",
+        "operationId": "listWorkflows",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/v1ListWorkflowsResponse"
+            }
+          },
+          "400": {
+            "description": "The request attempted has invalid parameters",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "401": {
+            "description": "Returned if authentication information is invalid",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "403": {
+            "description": "Returned when a user does not have permission to the resource.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "404": {
+            "description": "Returned when a resource is not found.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "429": {
+            "description": "Returned when a resource limit has been reached.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "500": {
+            "description": "Returned when an internal server error happens.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "filter",
+            "description": "[AIP-160](https://google.aip.dev/160) filter\nSupported fields:\n- string action: \"stake\", \"unstake\"\n- string protocol: \"ethereum_kiln\"\n- string network: \"holesky\", \"mainnet\"",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "description": "The maximum number of workflows to return. The service may\nreturn fewer than this value.\n\nIf unspecified, 100 workflows will be returned.\nThe maximum value is 1000; values over 1000 will be floored to 1000.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "A page token as part of the response of a previous call.\nProvide this to retrieve the next page.\n\nWhen paginating, all other parameters must match the previous\nrequest to list resources.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Workflow"
+        ]
+      },
+      "post": {
+        "summary": "Create workflow",
+        "operationId": "createWorkflow",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/v1Workflow"
+            }
+          },
+          "400": {
+            "description": "The request attempted has invalid parameters",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "401": {
+            "description": "Returned if authentication information is invalid",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "403": {
+            "description": "Returned when a user does not have permission to the resource.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "404": {
+            "description": "Returned when a resource is not found.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "429": {
+            "description": "Returned when a resource limit has been reached.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "500": {
+            "description": "Returned when an internal server error happens.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workflow",
+            "description": "The workflow to create.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1Workflow",
+              "required": [
+                "workflow"
+              ]
+            }
+          }
+        ],
+        "tags": [
+          "Workflow"
+        ]
+      }
+    },
     "/v1/{name}": {
       "get": {
         "summary": "Get workflow",
@@ -246,11 +400,11 @@
         "parameters": [
           {
             "name": "name",
-            "description": "The resource name of the workflow.\nFormat: projects/{project}/workflows/{workflow}",
+            "description": "The resource name of the workflow.\nFormat: workflows/{workflow}",
             "in": "path",
             "required": true,
             "type": "string",
-            "pattern": "projects/[^/]+/workflows/[^/]+"
+            "pattern": "workflows/[^/]+"
           }
         ],
         "tags": [
@@ -316,11 +470,11 @@
         "parameters": [
           {
             "name": "name",
-            "description": "The resource name of the workflow.\nFormat: projects/{project}/workflows/{workflow}",
+            "description": "The resource name of the workflow.\nFormat: workflows/{workflow}",
             "in": "path",
             "required": true,
             "type": "string",
-            "pattern": "projects/[^/]+/workflows/[^/]+"
+            "pattern": "workflows/[^/]+"
           },
           {
             "name": "body",
@@ -558,176 +712,6 @@
         ],
         "tags": [
           "StakingTarget"
-        ]
-      }
-    },
-    "/v1/{parent}/workflows": {
-      "get": {
-        "summary": "List supported workflows",
-        "operationId": "listWorkflows",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/v1ListWorkflowsResponse"
-            }
-          },
-          "400": {
-            "description": "The request attempted has invalid parameters",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "401": {
-            "description": "Returned if authentication information is invalid",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "403": {
-            "description": "Returned when a user does not have permission to the resource.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "404": {
-            "description": "Returned when a resource is not found.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "429": {
-            "description": "Returned when a resource limit has been reached.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "500": {
-            "description": "Returned when an internal server error happens.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "parent",
-            "description": "The resource name of the parent that owns\nthe collection of networks.\nFormat: projects/{project}",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "pattern": "projects/[^/]+"
-          },
-          {
-            "name": "filter",
-            "description": "[AIP-160](https://google.aip.dev/160) filter\nSupported fields:\n- string action: \"stake\", \"unstake\"\n- string protocol: \"ethereum_kiln\"\n- string network: \"holesky\", \"mainnet\"",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "pageSize",
-            "description": "The maximum number of workflows to return. The service may\nreturn fewer than this value.\n\nIf unspecified, 100 workflows will be returned.\nThe maximum value is 1000; values over 1000 will be floored to 1000.",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int32"
-          },
-          {
-            "name": "pageToken",
-            "description": "A page token as part of the response of a previous call.\nProvide this to retrieve the next page.\n\nWhen paginating, all other parameters must match the previous\nrequest to list resources.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Workflow"
-        ]
-      },
-      "post": {
-        "summary": "Create workflow",
-        "operationId": "createWorkflow",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/v1Workflow"
-            }
-          },
-          "400": {
-            "description": "The request attempted has invalid parameters",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "401": {
-            "description": "Returned if authentication information is invalid",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "403": {
-            "description": "Returned when a user does not have permission to the resource.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "404": {
-            "description": "Returned when a resource is not found.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "429": {
-            "description": "Returned when a resource limit has been reached.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "500": {
-            "description": "Returned when an internal server error happens.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "parent",
-            "description": "The resource name of the parent that owns\nthe workflow.\nFormat: projects/{project}",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "pattern": "projects/[^/]+"
-          },
-          {
-            "name": "workflow",
-            "description": "The workflow to create.",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1Workflow",
-              "required": [
-                "workflow"
-              ]
-            }
-          }
-        ],
-        "tags": [
-          "Workflow"
         ]
       }
     }
@@ -970,6 +954,39 @@
         "amount"
       ]
     },
+    "v1EthereumNativeStakeParameters": {
+      "type": "object",
+      "properties": {
+        "withdrawalAddress": {
+          "type": "string",
+          "title": "Ethereum address used to withdrawal funds"
+        },
+        "feeRecipient": {
+          "type": "string",
+          "title": "Ethereum address used to accumulate fees"
+        },
+        "amount": {
+          "$ref": "#/definitions/v1Amount",
+          "title": "Amount of ETH to stake in increments of 32"
+        }
+      },
+      "title": "Ethereum: Native Stake Parameters",
+      "required": [
+        "withdrawalAddress",
+        "feeRecipient",
+        "amount"
+      ]
+    },
+    "v1EthereumStakingParameters": {
+      "type": "object",
+      "properties": {
+        "nativeStakeParameters": {
+          "$ref": "#/definitions/v1EthereumNativeStakeParameters",
+          "title": "Native staking parameters"
+        }
+      },
+      "title": "Ethereum: Staking Parameters"
+    },
     "v1ListActionsResponse": {
       "type": "object",
       "properties": {
@@ -1083,6 +1100,28 @@
         }
       },
       "description": "A Protocol resource (e.g. ethereum_kiln, solana etc.)."
+    },
+    "v1ProvisionInfraStepOutput": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/v1ProvisionInfraStepOutputState",
+          "description": "The state of the provision infra step.",
+          "readOnly": true
+        }
+      },
+      "description": "The details for an infrastructure provision request."
+    },
+    "v1ProvisionInfraStepOutputState": {
+      "type": "string",
+      "enum": [
+        "STATE_UNSPECIFIED",
+        "STATE_IN_PROGRESS",
+        "STATE_COMPLETED",
+        "STATE_FAILED"
+      ],
+      "default": "STATE_UNSPECIFIED",
+      "description": "State defines an enumeration of states for provisioning infra.\n\n - STATE_UNSPECIFIED: Unspecified step state.\n - STATE_IN_PROGRESS: Provision step is in-progress.\n - STATE_COMPLETED: Provision step completed.\n - STATE_FAILED: Provision step failed."
     },
     "v1SolanaClaimStakeParameters": {
       "type": "object",
@@ -1387,7 +1426,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "title": "The resource name of the workflow.\nFormat: projects/{projectUUID}/workflows/{workflowUUID}\nEx: projects/ 123e4567-e89b-12d3-a456-426614174000/workflows/123e4567-e89b-12d3-a456-426614174000",
+          "title": "The resource name of the workflow.\nFormat: workflows/{workflowUUID}\nEx: workflows/123e4567-e89b-12d3-a456-426614174000",
           "readOnly": true
         },
         "action": {
@@ -1401,6 +1440,10 @@
         "ethereumKilnStakingParameters": {
           "$ref": "#/definitions/v1EthereumKilnStakingParameters",
           "description": "EthereumKiln staking parameters."
+        },
+        "ethereumStakingParameters": {
+          "$ref": "#/definitions/v1EthereumStakingParameters",
+          "description": "Ethereum staking parameters."
         },
         "state": {
           "$ref": "#/definitions/v1WorkflowState",
@@ -1445,7 +1488,8 @@
       "required": [
         "action",
         "solanaStakingParameters",
-        "ethereumKilnStakingParameters"
+        "ethereumKilnStakingParameters",
+        "ethereumStakingParameters"
       ]
     },
     "v1WorkflowState": {
@@ -1477,6 +1521,11 @@
         "waitStepOutput": {
           "$ref": "#/definitions/v1WaitStepOutput",
           "description": "The waiting details for any kind like how many checkpoints away for unbonding etc.",
+          "readOnly": true
+        },
+        "provisionInfraStepOutput": {
+          "$ref": "#/definitions/v1ProvisionInfraStepOutput",
+          "description": "The details for provisioned infrastructure.",
           "readOnly": true
         }
       },

--- a/docs/openapi/rewards.swagger.json
+++ b/docs/openapi/rewards.swagger.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "Coinbase Rewards API",
-    "description": "API that delivers crypto-forward onchain staking-related rewards data",
+    "title": "Rewards Service",
+    "description": "Service that provides access to onchain, staking-related rewards data.",
     "version": "v1"
   },
   "tags": [
@@ -30,66 +30,6 @@
     "application/json"
   ],
   "paths": {
-    "/v1/{name}": {
-      "get": {
-        "summary": "Returns a staking balance",
-        "description": "Returns a specific staking balance for an address on the specific protocol at a particular point in time.",
-        "operationId": "RewardService_GetStake",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/v1Stake"
-            }
-          },
-          "400": {
-            "description": "The request attempted has invalid parameters",
-            "schema": {
-              "example": {
-                "code": 3,
-                "message": "Invalid stake ID. \u003cRemediation assistance here\u003e.",
-                "details": []
-              }
-            }
-          },
-          "401": {
-            "description": "Returned if authentication information is invalid",
-            "schema": {
-              "example": "Unauthorized"
-            }
-          },
-          "500": {
-            "description": "Returned when an internal server error happens.",
-            "schema": {
-              "example": {
-                "code": 3,
-                "message": "Internal server error.",
-                "details": []
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "name",
-            "description": "The resource name of the stake to retrieve.\nFormat: protocols/{protocol}/stakes/{stake}",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "pattern": "protocols/[^/]+/stakes/[^/]+"
-          }
-        ],
-        "tags": [
-          "Stake"
-        ]
-      }
-    },
     "/v1/{parent}/rewards": {
       "get": {
         "summary": "List and filter rewards",
@@ -197,7 +137,7 @@
           },
           {
             "name": "filter",
-            "description": "[AIP-160](https://google.aip.dev/160) format compliant filter. Supported protocols are 'ethereum', 'solana', and 'cosmos'.\nSupplying other protocols will return an error.\n* **Ethereum**:\n  - Fields:\n  - `address` - A ethereum validator public key.\n  - `epoch` - An ethereum epoch. Supports epoch comparisons (ex: `epoch \u003e= 1000 AND epoch \u003c= 2000`).\n  - Example(s):\n  - `\"address='0xac53512c39d0081ca4437c285305eb423f474e6153693c12fbba4a3df78bcaa3422b31d800c5bea71c1b017168a60474' AND epoch \u003e= 234640 AND epoch \u003c 234645\"`\n\n* **Solana**:\n  - Fields:\n  - `address` - A solana validator or delegator address.\n  - `epoch` - A solana epoch. Supports epoch comparisons (ex: `epoch \u003e= 1000 AND epoch \u003c= 2000`).\n  - Example(s):\n  - `\"address='beefKGBWeSpHzYBHZXwp5So7wdQGX6mu4ZHCsH3uTar' AND epoch \u003e= 440 AND epoch \u003c 450\"`\n\n* **Cosmos**:\n  - Fields:\n  - `address` - A cosmos validator or delegator address (ex: `cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en` and `cosmos1c4k24jzduc365kywrsvf5ujz4ya6mwymy8vq4q`)\n  - `date` - A date in format 'YYYY-MM-DD'. Supports multiple comparisons (ex: `date \u003e= '2023-07-01' AND date \u003c= '2023-07-31'`).\n  - Example(s):\n  - `address='cosmos1mfduj0qax6ut8rd6cfc4j0ds06z0mwlhrljhqh' AND date = '2023-10-16'`",
+            "description": "[AIP-160](https://google.aip.dev/160) format compliant filter. Supported protocols are 'ethereum', 'solana', and 'cosmos'.\nSupplying other protocols will return an error.\n* **Ethereum**:\n  - Fields:\n  - `address` - A ethereum validator public key.\n  - `date` - A date in format 'YYYY-MM-DD'. Supports multiple comparisons (ex: '2024-01-15).\n  - `period_end_time` - A timestamp in RFC-3339 format. Supports multiple comparisons (ex: '2024-01-01T00:00:00Z' and '2024-01-15T00:00:00Z').\n  - Example(s):\n  - `\"address='0xac53512c39d0081ca4437c285305eb423f474e6153693c12fbba4a3df78bcaa3422b31d800c5bea71c1b017168a60474' AND date \u003e= '2024-01-01' AND date \u003c '2024-01-15'\"`\n  - `\"address='0xac53512c39d0081ca4437c285305eb423f474e6153693c12fbba4a3df78bcaa3422b31d800c5bea71c1b017168a60474' AND period_end_time \u003e= '2024-01-01T00:00:00Z' AND period_end_time \u003c '2024-01-15T00:00:00Z'\"`\n  - `\"address='0xac53512c39d0081ca4437c285305eb423f474e6153693c12fbba4a3df78bcaa3422b31d800c5bea71c1b017168a60474' AND date = '2024-01-01'\"`\n\n* **Solana**:\n  - Fields:\n  - `address` - A solana validator or delegator address.\n  - `epoch` - A solana epoch. Supports epoch comparisons (ex: `epoch \u003e= 1000 AND epoch \u003c= 2000`).\n  - `period_end_time` - A timestamp in RFC-3339 format. Supports multiple comparisons (ex: '2024-01-01T00:00:00Z' and '2024-01-15T00:00:00Z').\n  - Example(s):\n  - `\"address='beefKGBWeSpHzYBHZXwp5So7wdQGX6mu4ZHCsH3uTar' AND epoch \u003e= 540 AND epoch \u003c 550\"`\n  - `\"address='beefKGBWeSpHzYBHZXwp5So7wdQGX6mu4ZHCsH3uTar' AND period_end_time \u003e= '2024-01-01T00:00:00Z' AND period_end_time \u003c '2024-01-15T00:00:00Z'\"`\n  - `\"address='beefKGBWeSpHzYBHZXwp5So7wdQGX6mu4ZHCsH3uTar' AND epoch = 550\"`\n\n* **Cosmos**:\n  - Fields:\n  - `address` - A cosmos validator or delegator address (ex: `cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en` and `cosmos1c4k24jzduc365kywrsvf5ujz4ya6mwymy8vq4q`)\n  - `date` - A date in format 'YYYY-MM-DD'. Supports multiple comparisons (ex: '2024-01-15).\n  - `period_end_time` - A timestamp in RFC-3339 format. Supports multiple comparisons (ex: '2024-01-01T00:00:00Z' and '2024-01-15T00:00:00Z').\n  - Example(s):\n  - `\"address='cosmos1mfduj0qax6ut8rd6cfc4j0ds06z0mwlhrljhqh' AND date = '2024-11-16'\"`\n  - `\"address='cosmos1mfduj0qax6ut8rd6cfc4j0ds06z0mwlhrljhqh' AND period_end_time \u003e= '2024-01-01T00:00:00Z' AND period_end_time \u003c '2024-01-15T00:00:00Z'\"`\n  - `\"address='cosmos1mfduj0qax6ut8rd6cfc4j0ds06z0mwlhrljhqh' AND date = '2024-01-01'\"`",
             "in": "query",
             "required": false,
             "type": "string"
@@ -279,7 +219,14 @@
           },
           {
             "name": "filter",
-            "description": "[AIP-160](https://google.aip.dev/160) filter",
+            "description": "[AIP-160](https://google.aip.dev/160) format compliant filter. Supported protocols are 'ethereum', 'solana'.\nSupplying other protocols will return an error.\n* **Ethereum**:\n  - Fields:\n  - `address` - A ethereum validator public key.\n  - `evaluation_time` - A timestamp in RFC-3339 format. Supports multiple comparisons (ex: '2024-01-01T00:00:00Z' and '2024-01-15T00:00:00Z').\n  - Example(s):\n  - `\"address='0xac53512c39d0081ca4437c285305eb423f474e6153693c12fbba4a3df78bcaa3422b31d800c5bea71c1b017168a60474'\"`\n  - `\"address='0xac53512c39d0081ca4437c285305eb423f474e6153693c12fbba4a3df78bcaa3422b31d800c5bea71c1b017168a60474' AND evaluation_time \u003e= '2024-01-01T00:00:00Z' AND evaluation_time \u003c '2024-01-15T00:00:00Z'\"`\n\n* **Solana**:\n  - Fields:\n  - `address` - A solana staking address.\n  - `evaluation_time` - A timestamp in RFC-3339 format. Supports multiple comparisons (ex: '2024-01-01T00:00:00Z' and '2024-01-15T00:00:00Z').\n  - Example(s):\n  - `\"address='beefKGBWeSpHzYBHZXwp5So7wdQGX6mu4ZHCsH3uTar'\"`\n  - `\"address='beefKGBWeSpHzYBHZXwp5So7wdQGX6mu4ZHCsH3uTar' AND evaluation_time \u003e= '2024-01-01T00:00:00Z' AND evaluation_time \u003c '2024-01-15T00:00:00Z'\"`",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "description": "The order in which to sort the results.\n[AIP-132](https://google.aip.dev/132) compliant order_by field.\nThe default behavior, if not supplied, is 'evaluation_time desc'.\nExample(s):\n* 'evaluation_time desc', which returns Stakes starting with the most recent.\n* 'evaluation_time asc', which returns Stakes starting with the oldest available.\n* 'evaluation_time', which returns Stakes starting with the oldest available.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -379,6 +326,7 @@
         },
         "exp": {
           "type": "string",
+          "format": "int64",
           "description": "The number of decimals needed to convert from the raw numeric value to the most\ncommon denomination.",
           "readOnly": true
         },
@@ -472,13 +420,13 @@
         "periodStartTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The starting time of this reward period. Returned when querying by epoch.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z). UTC offsets are not currently supported.\nField currently unavailable. Coming soon.",
+          "description": "The starting time of this reward period. Returned when querying by epoch.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2024-11-13T19:38:36Z).\nField currently unavailable. Coming soon.",
           "readOnly": true
         },
         "periodEndTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The ending time of this reward period. Returned when querying by epoch.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z). UTC offsets are not currently supported.",
+          "description": "The ending time of this reward period. Returned when querying by epoch.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2024-11-13T19:38:36Z).",
           "readOnly": true
         },
         "totalEarnedNativeUnit": {
@@ -519,7 +467,7 @@
         "calculatedTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The time at which this yield calculation was calculated.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z). UTC offsets are not currently supported.",
+          "description": "The time at which this yield calculation was calculated.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z).",
           "readOnly": true
         },
         "calculationMethod": {
@@ -541,7 +489,7 @@
         "evaluationTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The time at which this balance was evaluated.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z). UTC offsets are not currently supported.",
+          "description": "The time at which this balance was evaluated.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z).",
           "readOnly": true
         },
         "bondedStake": {
@@ -602,12 +550,17 @@
         "conversionTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The timestamp at which the USD value was sourced to convert the value into USD.\nThis value is as close to the time the reward was earned as possible.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2023-11-13T19:38:36Z). UTC offsets are not currently supported.",
+          "description": "The timestamp at which the USD value was sourced to convert the value into USD.\nThis value is as close to the time the reward was earned as possible.\nTimestamps are in UTC, conforming to the RFC-3339 spec (e.g. 2024-11-13T19:38:36Z).",
           "readOnly": true
         },
         "amount": {
           "$ref": "#/definitions/v1AssetAmount",
-          "description": "The USD value of the reward at the conversion time..",
+          "description": "The USD value of the reward at the conversion time.",
+          "readOnly": true
+        },
+        "conversionPrice": {
+          "type": "string",
+          "description": "The price of the native unit at the conversion time.",
           "readOnly": true
         }
       },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rimraf ./dist",
+    "gen": "./scripts/generate-client.sh",
     "build": "npm run clean && tsc",
     "prepare": "npm run build",
     "lint": "eslint . --ext .ts --ignore-pattern '/dist/*/*'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rimraf ./dist",
-    "gen": "./scripts/generate-client.sh",
+    "gen": "npm run clean-gen && ./scripts/generate-client.sh",
+    "clean-gen": "rm -rf src/gen/* && rm -rf docs/openapi/*",
     "build": "npm run clean && tsc",
     "prepare": "npm run build",
     "lint": "eslint . --ext .ts --ignore-pattern '/dist/*/*'",

--- a/protos/buf.gen.orchestration.yaml
+++ b/protos/buf.gen.orchestration.yaml
@@ -1,0 +1,11 @@
+version: v1
+plugins:
+  - name: grpc-gateway-ts
+    out: ./src/gen/
+    opt:
+      - paths=source_relative
+  - name: openapiv2
+    out: ./docs/openapi
+    opt:
+      - allow_merge=true
+      - merge_file_name=orchestration

--- a/protos/buf.gen.rewards.yaml
+++ b/protos/buf.gen.rewards.yaml
@@ -1,0 +1,11 @@
+version: v1
+plugins:
+  - name: grpc-gateway-ts
+    out: ./src/gen/
+    opt:
+      - paths=source_relative
+  - name: openapiv2
+    out: ./docs/openapi
+    opt:
+      - allow_merge=true
+      - merge_file_name=rewards

--- a/scripts/generate-client.sh
+++ b/scripts/generate-client.sh
@@ -3,4 +3,4 @@
 buf generate --template protos/buf.gen.orchestration.yaml buf.build/cdp/orchestration --path coinbase/staking/orchestration/v1 --include-imports --include-wkt
 buf generate --template protos/buf.gen.rewards.yaml buf.build/cdp/rewards --path coinbase/staking/rewards/v1 --include-imports --include-wkt
 # TODO: Remove this once the generation issue is fixed.
-find ./src/gen -type f -exec sed -I '' -e 's/parentprotocols/parent/g' -e 's/parentprotocolsnetworks/parents/g' -e 's/parentnetworks/parent/g' -e 's/nameprojectsworkflows/name/g' -e 's/parentprojects/parent/g' {} \;
+find ./src/gen -type f -exec sed -I '' -e 's/parentprotocols/parent/g' -e 's/parentprotocolsnetworks/parents/g' -e 's/parentnetworks/parent/g' -e 's/nameprojectsworkflows/name/g' -e 's/parentprojects/parent/g' -e 's/nameworkflows/name/g' {} \;

--- a/scripts/generate-client.sh
+++ b/scripts/generate-client.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+buf generate --template protos/buf.gen.orchestration.yaml buf.cbhq.net/cloud/staking --path coinbase/staking/orchestration/v1 --include-imports --include-wkt
+buf generate --template protos/buf.gen.rewards.yaml buf.cbhq.net/cloud/rewards-reporting-protos-rewards --path coinbase/staking/rewards/v1 --include-imports --include-wkt
+# TODO: Remove this once the generation issue is fixed.
+find ./src/gen -type f -exec sed -I '' -e 's/parentprotocols/parent/g' -e 's/parentprotocolsnetworks/parents/g' -e 's/parentnetworks/parent/g' -e 's/nameprojectsworkflows/name/g' -e 's/parentprojects/parent/g' {} \;

--- a/scripts/generate-client.sh
+++ b/scripts/generate-client.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-buf generate --template protos/buf.gen.orchestration.yaml buf.cbhq.net/cloud/staking --path coinbase/staking/orchestration/v1 --include-imports --include-wkt
-buf generate --template protos/buf.gen.rewards.yaml buf.cbhq.net/cloud/rewards-reporting-protos-rewards --path coinbase/staking/rewards/v1 --include-imports --include-wkt
+buf generate --template protos/buf.gen.orchestration.yaml buf.build/cdp/orchestration --path coinbase/staking/orchestration/v1 --include-imports --include-wkt
+buf generate --template protos/buf.gen.rewards.yaml buf.build/cdp/rewards --path coinbase/staking/rewards/v1 --include-imports --include-wkt
 # TODO: Remove this once the generation issue is fixed.
 find ./src/gen -type f -exec sed -I '' -e 's/parentprotocols/parent/g' -e 's/parentprotocolsnetworks/parents/g' -e 's/parentnetworks/parent/g' -e 's/nameprojectsworkflows/name/g' -e 's/parentprojects/parent/g' {} \;

--- a/src/client/protocols/ethereum-kiln-staking.ts
+++ b/src/client/protocols/ethereum-kiln-staking.ts
@@ -31,7 +31,6 @@ export class Ethereum {
     amount: string,
   ): Promise<Workflow> {
     const req: CreateWorkflowRequest = {
-      parent: `projects/${projectId}`,
       workflow: {
         action: `protocols/ethereum_kiln/networks/${network}/actions/stake`,
         ethereumKilnStakingParameters: {
@@ -58,7 +57,6 @@ export class Ethereum {
     amount: string,
   ): Promise<Workflow> {
     const req: CreateWorkflowRequest = {
-      parent: `projects/${projectId}`,
       workflow: {
         action: `protocols/ethereum_kiln/networks/${network}/actions/unstake`,
         ethereumKilnStakingParameters: {
@@ -84,7 +82,6 @@ export class Ethereum {
     integratorContractAddress: string,
   ): Promise<Workflow> {
     const req: CreateWorkflowRequest = {
-      parent: `projects/${projectId}`,
       workflow: {
         action: `protocols/ethereum_kiln/networks/${network}/actions/claim_stake`,
         ethereumKilnStakingParameters: {

--- a/src/client/protocols/solana-staking.ts
+++ b/src/client/protocols/solana-staking.ts
@@ -31,7 +31,6 @@ export class Solana {
     amount: string,
   ): Promise<Workflow> {
     const req: CreateWorkflowRequest = {
-      parent: `projects/${projectId}`,
       workflow: {
         action: `protocols/solana/networks/${network}/actions/stake`,
         solanaStakingParameters: {
@@ -58,7 +57,6 @@ export class Solana {
     amount: string,
   ): Promise<Workflow> {
     const req: CreateWorkflowRequest = {
-      parent: `projects/${projectId}`,
       workflow: {
         action: `protocols/solana/networks/${network}/actions/unstake`,
         solanaStakingParameters: {
@@ -84,7 +82,6 @@ export class Solana {
     stakeAccountAddress: string,
   ): Promise<Workflow> {
     const req: CreateWorkflowRequest = {
-      parent: `projects/${projectId}`,
       workflow: {
         action: `protocols/solana/networks/${network}/actions/claim_stake`,
         solanaStakingParameters: {

--- a/src/client/staking-client.ts
+++ b/src/client/staking-client.ts
@@ -205,7 +205,6 @@ export class StakingClient {
     const initReq = await getAuthDetails(url, path, method);
 
     const req: ListWorkflowsRequest = {
-      parent: parent,
       pageSize: pageSize,
       filter: filter,
     };

--- a/src/gen/coinbase/staking/orchestration/v1/api.pb.ts
+++ b/src/gen/coinbase/staking/orchestration/v1/api.pb.ts
@@ -25,16 +25,16 @@ export class StakingService {
     return fm.fetchReq<CoinbaseStakingOrchestrationV1Action.ListActionsRequest, CoinbaseStakingOrchestrationV1Action.ListActionsResponse>(`/v1/${req["parent"]}/actions?${fm.renderURLSearchParams(req, ["parent"])}`, {...initReq, method: "GET"})
   }
   static CreateWorkflow(req: CoinbaseStakingOrchestrationV1Workflow.CreateWorkflowRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.Workflow> {
-    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.CreateWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["parent"]}/workflows`, {...initReq, method: "POST", body: JSON.stringify(req["workflow"], fm.replacer)})
+    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.CreateWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/workflows`, {...initReq, method: "POST", body: JSON.stringify(req["workflow"], fm.replacer)})
   }
   static GetWorkflow(req: CoinbaseStakingOrchestrationV1Workflow.GetWorkflowRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.Workflow> {
-    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.GetWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["name"]}?${fm.renderURLSearchParams(req, ["name"])}`, {...initReq, method: "GET"})
+    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.GetWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["nameworkflows"]}?${fm.renderURLSearchParams(req, ["nameworkflows"])}`, {...initReq, method: "GET"})
   }
   static ListWorkflows(req: CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsResponse> {
-    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsRequest, CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsResponse>(`/v1/${req["parent"]}/workflows?${fm.renderURLSearchParams(req, ["parent"])}`, {...initReq, method: "GET"})
+    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsRequest, CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsResponse>(`/v1/workflows?${fm.renderURLSearchParams(req, [])}`, {...initReq, method: "GET"})
   }
   static PerformWorkflowStep(req: CoinbaseStakingOrchestrationV1Workflow.PerformWorkflowStepRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.Workflow> {
-    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.PerformWorkflowStepRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["name"]}/step`, {...initReq, method: "POST", body: JSON.stringify(req, fm.replacer)})
+    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.PerformWorkflowStepRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["nameworkflows"]}/step`, {...initReq, method: "POST", body: JSON.stringify(req, fm.replacer)})
   }
   static ViewStakingContext(req: CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextResponse> {
     return fm.fetchReq<CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextRequest, CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextResponse>(`/v1/viewStakingContext:view?${fm.renderURLSearchParams(req, [])}`, {...initReq, method: "GET"})

--- a/src/gen/coinbase/staking/orchestration/v1/api.pb.ts
+++ b/src/gen/coinbase/staking/orchestration/v1/api.pb.ts
@@ -28,13 +28,13 @@ export class StakingService {
     return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.CreateWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/workflows`, {...initReq, method: "POST", body: JSON.stringify(req["workflow"], fm.replacer)})
   }
   static GetWorkflow(req: CoinbaseStakingOrchestrationV1Workflow.GetWorkflowRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.Workflow> {
-    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.GetWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["nameworkflows"]}?${fm.renderURLSearchParams(req, ["nameworkflows"])}`, {...initReq, method: "GET"})
+    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.GetWorkflowRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["name"]}?${fm.renderURLSearchParams(req, ["name"])}`, {...initReq, method: "GET"})
   }
   static ListWorkflows(req: CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsResponse> {
     return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsRequest, CoinbaseStakingOrchestrationV1Workflow.ListWorkflowsResponse>(`/v1/workflows?${fm.renderURLSearchParams(req, [])}`, {...initReq, method: "GET"})
   }
   static PerformWorkflowStep(req: CoinbaseStakingOrchestrationV1Workflow.PerformWorkflowStepRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Workflow.Workflow> {
-    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.PerformWorkflowStepRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["nameworkflows"]}/step`, {...initReq, method: "POST", body: JSON.stringify(req, fm.replacer)})
+    return fm.fetchReq<CoinbaseStakingOrchestrationV1Workflow.PerformWorkflowStepRequest, CoinbaseStakingOrchestrationV1Workflow.Workflow>(`/v1/${req["name"]}/step`, {...initReq, method: "POST", body: JSON.stringify(req, fm.replacer)})
   }
   static ViewStakingContext(req: CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextResponse> {
     return fm.fetchReq<CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextRequest, CoinbaseStakingOrchestrationV1Staking_context.ViewStakingContextResponse>(`/v1/viewStakingContext:view?${fm.renderURLSearchParams(req, [])}`, {...initReq, method: "GET"})

--- a/src/gen/coinbase/staking/orchestration/v1/ethereum.pb.ts
+++ b/src/gen/coinbase/staking/orchestration/v1/ethereum.pb.ts
@@ -1,0 +1,28 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+import * as CoinbaseStakingOrchestrationV1Common from "./common.pb"
+
+type Absent<T, K extends keyof T> = { [k in Exclude<keyof T, K>]?: undefined };
+type OneOf<T> =
+  | { [k in keyof T]?: undefined }
+  | (
+    keyof T extends infer K ?
+      (K extends string & keyof T ? { [k in K]: T[K] } & Absent<T, K>
+        : never)
+    : never);
+
+type BaseEthereumStakingParameters = {
+}
+
+export type EthereumStakingParameters = BaseEthereumStakingParameters
+  & OneOf<{ nativeStakeParameters: EthereumNativeStakeParameters }>
+
+export type EthereumNativeStakeParameters = {
+  withdrawalAddress?: string
+  feeRecipient?: string
+  amount?: CoinbaseStakingOrchestrationV1Common.Amount
+}

--- a/src/gen/coinbase/staking/orchestration/v1/workflow.pb.ts
+++ b/src/gen/coinbase/staking/orchestration/v1/workflow.pb.ts
@@ -5,6 +5,7 @@
 */
 
 import * as GoogleProtobufTimestamp from "../../../../google/protobuf/timestamp.pb"
+import * as CoinbaseStakingOrchestrationV1Ethereum from "./ethereum.pb"
 import * as CoinbaseStakingOrchestrationV1Ethereum_kiln from "./ethereum_kiln.pb"
 import * as CoinbaseStakingOrchestrationV1Solana from "./solana.pb"
 
@@ -46,6 +47,13 @@ export enum WaitStepOutputState {
   STATE_COMPLETED = "STATE_COMPLETED",
 }
 
+export enum ProvisionInfraStepOutputState {
+  STATE_UNSPECIFIED = "STATE_UNSPECIFIED",
+  STATE_IN_PROGRESS = "STATE_IN_PROGRESS",
+  STATE_COMPLETED = "STATE_COMPLETED",
+  STATE_FAILED = "STATE_FAILED",
+}
+
 export enum WorkflowState {
   STATE_UNSPECIFIED = "STATE_UNSPECIFIED",
   STATE_IN_PROGRESS = "STATE_IN_PROGRESS",
@@ -70,13 +78,17 @@ export type WaitStepOutput = {
   state?: WaitStepOutputState
 }
 
+export type ProvisionInfraStepOutput = {
+  state?: ProvisionInfraStepOutputState
+}
+
 
 type BaseWorkflowStep = {
   name?: string
 }
 
 export type WorkflowStep = BaseWorkflowStep
-  & OneOf<{ txStepOutput: TxStepOutput; waitStepOutput: WaitStepOutput }>
+  & OneOf<{ txStepOutput: TxStepOutput; waitStepOutput: WaitStepOutput; provisionInfraStepOutput: ProvisionInfraStepOutput }>
 
 
 type BaseWorkflow = {
@@ -91,10 +103,9 @@ type BaseWorkflow = {
 }
 
 export type Workflow = BaseWorkflow
-  & OneOf<{ solanaStakingParameters: CoinbaseStakingOrchestrationV1Solana.SolanaStakingParameters; ethereumKilnStakingParameters: CoinbaseStakingOrchestrationV1Ethereum_kiln.EthereumKilnStakingParameters }>
+  & OneOf<{ solanaStakingParameters: CoinbaseStakingOrchestrationV1Solana.SolanaStakingParameters; ethereumKilnStakingParameters: CoinbaseStakingOrchestrationV1Ethereum_kiln.EthereumKilnStakingParameters; ethereumStakingParameters: CoinbaseStakingOrchestrationV1Ethereum.EthereumStakingParameters }>
 
 export type CreateWorkflowRequest = {
-  parent?: string
   workflow?: Workflow
 }
 
@@ -103,7 +114,6 @@ export type GetWorkflowRequest = {
 }
 
 export type ListWorkflowsRequest = {
-  parent?: string
   filter?: string
   pageSize?: number
   pageToken?: string

--- a/src/gen/coinbase/staking/rewards/v1/reward.pb.ts
+++ b/src/gen/coinbase/staking/rewards/v1/reward.pb.ts
@@ -47,6 +47,7 @@ export type USDValue = {
   source?: USDValueSource
   conversionTime?: GoogleProtobufTimestamp.Timestamp
   amount?: CoinbaseStakingRewardsV1Common.AssetAmount
+  conversionPrice?: string
 }
 
 export type ListRewardsRequest = {

--- a/src/gen/coinbase/staking/rewards/v1/reward_service.pb.ts
+++ b/src/gen/coinbase/staking/rewards/v1/reward_service.pb.ts
@@ -11,9 +11,6 @@ export class RewardService {
   static ListRewards(req: CoinbaseStakingRewardsV1Reward.ListRewardsRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingRewardsV1Reward.ListRewardsResponse> {
     return fm.fetchReq<CoinbaseStakingRewardsV1Reward.ListRewardsRequest, CoinbaseStakingRewardsV1Reward.ListRewardsResponse>(`/v1/${req["parent"]}/rewards?${fm.renderURLSearchParams(req, ["parent"])}`, {...initReq, method: "GET"})
   }
-  static GetStake(req: CoinbaseStakingRewardsV1Stake.GetStakeRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingRewardsV1Stake.Stake> {
-    return fm.fetchReq<CoinbaseStakingRewardsV1Stake.GetStakeRequest, CoinbaseStakingRewardsV1Stake.Stake>(`/v1/${req["nameprotocolsstakes"]}?${fm.renderURLSearchParams(req, ["nameprotocolsstakes"])}`, {...initReq, method: "GET"})
-  }
   static ListStakes(req: CoinbaseStakingRewardsV1Stake.ListStakesRequest, initReq?: fm.InitReq): Promise<CoinbaseStakingRewardsV1Stake.ListStakesResponse> {
     return fm.fetchReq<CoinbaseStakingRewardsV1Stake.ListStakesRequest, CoinbaseStakingRewardsV1Stake.ListStakesResponse>(`/v1/${req["parent"]}/stakes?${fm.renderURLSearchParams(req, ["parent"])}`, {...initReq, method: "GET"})
   }

--- a/src/gen/coinbase/staking/rewards/v1/stake.pb.ts
+++ b/src/gen/coinbase/staking/rewards/v1/stake.pb.ts
@@ -41,7 +41,6 @@ type BaseStake = {
   address?: string
   evaluationTime?: GoogleProtobufTimestamp.Timestamp
   bondedStake?: CoinbaseStakingRewardsV1Common.AssetAmount
-  totalDelegationReceived?: CoinbaseStakingRewardsV1Common.AssetAmount
   rewardRateCalculations?: RewardRate[]
   participantType?: ParticipantType
   protocol?: string
@@ -49,6 +48,7 @@ type BaseStake = {
 }
 
 export type Stake = BaseStake
+  & OneOf<{ totalDelegationReceived: CoinbaseStakingRewardsV1Common.AssetAmount }>
   & OneOf<{ delegationsReceived: StakeDelegation }>
   & OneOf<{ delegationsGiven: StakeDelegation }>
 
@@ -63,13 +63,10 @@ export type ListStakesRequest = {
   pageSize?: number
   pageToken?: string
   filter?: string
+  orderBy?: string
 }
 
 export type ListStakesResponse = {
   stakes?: Stake[]
   nextPageToken?: string
-}
-
-export type GetStakeRequest = {
-  name?: string
 }

--- a/src/gen/google/api/annotations.pb.ts
+++ b/src/gen/google/api/annotations.pb.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/src/gen/google/api/client.pb.ts
+++ b/src/gen/google/api/client.pb.ts
@@ -1,0 +1,110 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+import * as GoogleProtobufDuration from "../protobuf/duration.pb"
+import * as GoogleApiLaunch_stage from "./launch_stage.pb"
+
+export enum ClientLibraryOrganization {
+  CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED = "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED",
+  CLOUD = "CLOUD",
+  ADS = "ADS",
+  PHOTOS = "PHOTOS",
+  STREET_VIEW = "STREET_VIEW",
+  SHOPPING = "SHOPPING",
+  GEO = "GEO",
+  GENERATIVE_AI = "GENERATIVE_AI",
+}
+
+export enum ClientLibraryDestination {
+  CLIENT_LIBRARY_DESTINATION_UNSPECIFIED = "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED",
+  GITHUB = "GITHUB",
+  PACKAGE_MANAGER = "PACKAGE_MANAGER",
+}
+
+export type CommonLanguageSettings = {
+  referenceDocsUri?: string
+  destinations?: ClientLibraryDestination[]
+}
+
+export type ClientLibrarySettings = {
+  version?: string
+  launchStage?: GoogleApiLaunch_stage.LaunchStage
+  restNumericEnums?: boolean
+  javaSettings?: JavaSettings
+  cppSettings?: CppSettings
+  phpSettings?: PhpSettings
+  pythonSettings?: PythonSettings
+  nodeSettings?: NodeSettings
+  dotnetSettings?: DotnetSettings
+  rubySettings?: RubySettings
+  goSettings?: GoSettings
+}
+
+export type Publishing = {
+  methodSettings?: MethodSettings[]
+  newIssueUri?: string
+  documentationUri?: string
+  apiShortName?: string
+  githubLabel?: string
+  codeownerGithubTeams?: string[]
+  docTagPrefix?: string
+  organization?: ClientLibraryOrganization
+  librarySettings?: ClientLibrarySettings[]
+  protoReferenceDocumentationUri?: string
+  restReferenceDocumentationUri?: string
+}
+
+export type JavaSettings = {
+  libraryPackage?: string
+  serviceClassNames?: {[key: string]: string}
+  common?: CommonLanguageSettings
+}
+
+export type CppSettings = {
+  common?: CommonLanguageSettings
+}
+
+export type PhpSettings = {
+  common?: CommonLanguageSettings
+}
+
+export type PythonSettings = {
+  common?: CommonLanguageSettings
+}
+
+export type NodeSettings = {
+  common?: CommonLanguageSettings
+}
+
+export type DotnetSettings = {
+  common?: CommonLanguageSettings
+  renamedServices?: {[key: string]: string}
+  renamedResources?: {[key: string]: string}
+  ignoredResources?: string[]
+  forcedNamespaceAliases?: string[]
+  handwrittenSignatures?: string[]
+}
+
+export type RubySettings = {
+  common?: CommonLanguageSettings
+}
+
+export type GoSettings = {
+  common?: CommonLanguageSettings
+}
+
+export type MethodSettingsLongRunning = {
+  initialPollDelay?: GoogleProtobufDuration.Duration
+  pollDelayMultiplier?: number
+  maxPollDelay?: GoogleProtobufDuration.Duration
+  totalPollTimeout?: GoogleProtobufDuration.Duration
+}
+
+export type MethodSettings = {
+  selector?: string
+  longRunning?: MethodSettingsLongRunning
+  autoPopulatedFields?: string[]
+}

--- a/src/gen/google/api/field_behavior.pb.ts
+++ b/src/gen/google/api/field_behavior.pb.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+export enum FieldBehavior {
+  FIELD_BEHAVIOR_UNSPECIFIED = "FIELD_BEHAVIOR_UNSPECIFIED",
+  OPTIONAL = "OPTIONAL",
+  REQUIRED = "REQUIRED",
+  OUTPUT_ONLY = "OUTPUT_ONLY",
+  INPUT_ONLY = "INPUT_ONLY",
+  IMMUTABLE = "IMMUTABLE",
+  UNORDERED_LIST = "UNORDERED_LIST",
+  NON_EMPTY_DEFAULT = "NON_EMPTY_DEFAULT",
+  IDENTIFIER = "IDENTIFIER",
+}

--- a/src/gen/google/api/http.pb.ts
+++ b/src/gen/google/api/http.pb.ts
@@ -1,0 +1,34 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+type Absent<T, K extends keyof T> = { [k in Exclude<keyof T, K>]?: undefined };
+type OneOf<T> =
+  | { [k in keyof T]?: undefined }
+  | (
+    keyof T extends infer K ?
+      (K extends string & keyof T ? { [k in K]: T[K] } & Absent<T, K>
+        : never)
+    : never);
+export type Http = {
+  rules?: HttpRule[]
+  fullyDecodeReservedExpansion?: boolean
+}
+
+
+type BaseHttpRule = {
+  selector?: string
+  body?: string
+  responseBody?: string
+  additionalBindings?: HttpRule[]
+}
+
+export type HttpRule = BaseHttpRule
+  & OneOf<{ get: string; put: string; post: string; delete: string; patch: string; custom: CustomHttpPattern }>
+
+export type CustomHttpPattern = {
+  kind?: string
+  path?: string
+}

--- a/src/gen/google/api/launch_stage.pb.ts
+++ b/src/gen/google/api/launch_stage.pb.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+export enum LaunchStage {
+  LAUNCH_STAGE_UNSPECIFIED = "LAUNCH_STAGE_UNSPECIFIED",
+  UNIMPLEMENTED = "UNIMPLEMENTED",
+  PRELAUNCH = "PRELAUNCH",
+  EARLY_ACCESS = "EARLY_ACCESS",
+  ALPHA = "ALPHA",
+  BETA = "BETA",
+  GA = "GA",
+  DEPRECATED = "DEPRECATED",
+}

--- a/src/gen/google/api/resource.pb.ts
+++ b/src/gen/google/api/resource.pb.ts
@@ -1,0 +1,31 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+export enum ResourceDescriptorHistory {
+  HISTORY_UNSPECIFIED = "HISTORY_UNSPECIFIED",
+  ORIGINALLY_SINGLE_PATTERN = "ORIGINALLY_SINGLE_PATTERN",
+  FUTURE_MULTI_PATTERN = "FUTURE_MULTI_PATTERN",
+}
+
+export enum ResourceDescriptorStyle {
+  STYLE_UNSPECIFIED = "STYLE_UNSPECIFIED",
+  DECLARATIVE_FRIENDLY = "DECLARATIVE_FRIENDLY",
+}
+
+export type ResourceDescriptor = {
+  type?: string
+  pattern?: string[]
+  nameField?: string
+  history?: ResourceDescriptorHistory
+  plural?: string
+  singular?: string
+  style?: ResourceDescriptorStyle[]
+}
+
+export type ResourceReference = {
+  type?: string
+  childType?: string
+}

--- a/src/gen/google/protobuf/descriptor.pb.ts
+++ b/src/gen/google/protobuf/descriptor.pb.ts
@@ -1,0 +1,395 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+export enum Edition {
+  EDITION_UNKNOWN = "EDITION_UNKNOWN",
+  EDITION_PROTO2 = "EDITION_PROTO2",
+  EDITION_PROTO3 = "EDITION_PROTO3",
+  EDITION_2023 = "EDITION_2023",
+  EDITION_1_TEST_ONLY = "EDITION_1_TEST_ONLY",
+  EDITION_2_TEST_ONLY = "EDITION_2_TEST_ONLY",
+  EDITION_99997_TEST_ONLY = "EDITION_99997_TEST_ONLY",
+  EDITION_99998_TEST_ONLY = "EDITION_99998_TEST_ONLY",
+  EDITION_99999_TEST_ONLY = "EDITION_99999_TEST_ONLY",
+}
+
+export enum ExtensionRangeOptionsVerificationState {
+  DECLARATION = "DECLARATION",
+  UNVERIFIED = "UNVERIFIED",
+}
+
+export enum FieldDescriptorProtoType {
+  TYPE_DOUBLE = "TYPE_DOUBLE",
+  TYPE_FLOAT = "TYPE_FLOAT",
+  TYPE_INT64 = "TYPE_INT64",
+  TYPE_UINT64 = "TYPE_UINT64",
+  TYPE_INT32 = "TYPE_INT32",
+  TYPE_FIXED64 = "TYPE_FIXED64",
+  TYPE_FIXED32 = "TYPE_FIXED32",
+  TYPE_BOOL = "TYPE_BOOL",
+  TYPE_STRING = "TYPE_STRING",
+  TYPE_GROUP = "TYPE_GROUP",
+  TYPE_MESSAGE = "TYPE_MESSAGE",
+  TYPE_BYTES = "TYPE_BYTES",
+  TYPE_UINT32 = "TYPE_UINT32",
+  TYPE_ENUM = "TYPE_ENUM",
+  TYPE_SFIXED32 = "TYPE_SFIXED32",
+  TYPE_SFIXED64 = "TYPE_SFIXED64",
+  TYPE_SINT32 = "TYPE_SINT32",
+  TYPE_SINT64 = "TYPE_SINT64",
+}
+
+export enum FieldDescriptorProtoLabel {
+  LABEL_OPTIONAL = "LABEL_OPTIONAL",
+  LABEL_REPEATED = "LABEL_REPEATED",
+  LABEL_REQUIRED = "LABEL_REQUIRED",
+}
+
+export enum FileOptionsOptimizeMode {
+  SPEED = "SPEED",
+  CODE_SIZE = "CODE_SIZE",
+  LITE_RUNTIME = "LITE_RUNTIME",
+}
+
+export enum FieldOptionsCType {
+  STRING = "STRING",
+  CORD = "CORD",
+  STRING_PIECE = "STRING_PIECE",
+}
+
+export enum FieldOptionsJSType {
+  JS_NORMAL = "JS_NORMAL",
+  JS_STRING = "JS_STRING",
+  JS_NUMBER = "JS_NUMBER",
+}
+
+export enum FieldOptionsOptionRetention {
+  RETENTION_UNKNOWN = "RETENTION_UNKNOWN",
+  RETENTION_RUNTIME = "RETENTION_RUNTIME",
+  RETENTION_SOURCE = "RETENTION_SOURCE",
+}
+
+export enum FieldOptionsOptionTargetType {
+  TARGET_TYPE_UNKNOWN = "TARGET_TYPE_UNKNOWN",
+  TARGET_TYPE_FILE = "TARGET_TYPE_FILE",
+  TARGET_TYPE_EXTENSION_RANGE = "TARGET_TYPE_EXTENSION_RANGE",
+  TARGET_TYPE_MESSAGE = "TARGET_TYPE_MESSAGE",
+  TARGET_TYPE_FIELD = "TARGET_TYPE_FIELD",
+  TARGET_TYPE_ONEOF = "TARGET_TYPE_ONEOF",
+  TARGET_TYPE_ENUM = "TARGET_TYPE_ENUM",
+  TARGET_TYPE_ENUM_ENTRY = "TARGET_TYPE_ENUM_ENTRY",
+  TARGET_TYPE_SERVICE = "TARGET_TYPE_SERVICE",
+  TARGET_TYPE_METHOD = "TARGET_TYPE_METHOD",
+}
+
+export enum MethodOptionsIdempotencyLevel {
+  IDEMPOTENCY_UNKNOWN = "IDEMPOTENCY_UNKNOWN",
+  NO_SIDE_EFFECTS = "NO_SIDE_EFFECTS",
+  IDEMPOTENT = "IDEMPOTENT",
+}
+
+export enum FeatureSetFieldPresence {
+  FIELD_PRESENCE_UNKNOWN = "FIELD_PRESENCE_UNKNOWN",
+  EXPLICIT = "EXPLICIT",
+  IMPLICIT = "IMPLICIT",
+  LEGACY_REQUIRED = "LEGACY_REQUIRED",
+}
+
+export enum FeatureSetEnumType {
+  ENUM_TYPE_UNKNOWN = "ENUM_TYPE_UNKNOWN",
+  OPEN = "OPEN",
+  CLOSED = "CLOSED",
+}
+
+export enum FeatureSetRepeatedFieldEncoding {
+  REPEATED_FIELD_ENCODING_UNKNOWN = "REPEATED_FIELD_ENCODING_UNKNOWN",
+  PACKED = "PACKED",
+  EXPANDED = "EXPANDED",
+}
+
+export enum FeatureSetUtf8Validation {
+  UTF8_VALIDATION_UNKNOWN = "UTF8_VALIDATION_UNKNOWN",
+  NONE = "NONE",
+  VERIFY = "VERIFY",
+}
+
+export enum FeatureSetMessageEncoding {
+  MESSAGE_ENCODING_UNKNOWN = "MESSAGE_ENCODING_UNKNOWN",
+  LENGTH_PREFIXED = "LENGTH_PREFIXED",
+  DELIMITED = "DELIMITED",
+}
+
+export enum FeatureSetJsonFormat {
+  JSON_FORMAT_UNKNOWN = "JSON_FORMAT_UNKNOWN",
+  ALLOW = "ALLOW",
+  LEGACY_BEST_EFFORT = "LEGACY_BEST_EFFORT",
+}
+
+export enum GeneratedCodeInfoAnnotationSemantic {
+  NONE = "NONE",
+  SET = "SET",
+  ALIAS = "ALIAS",
+}
+
+export type FileDescriptorSet = {
+  file?: FileDescriptorProto[]
+}
+
+export type FileDescriptorProto = {
+  name?: string
+  package?: string
+  dependency?: string[]
+  publicDependency?: number[]
+  weakDependency?: number[]
+  messageType?: DescriptorProto[]
+  enumType?: EnumDescriptorProto[]
+  service?: ServiceDescriptorProto[]
+  extension?: FieldDescriptorProto[]
+  options?: FileOptions
+  sourceCodeInfo?: SourceCodeInfo
+  syntax?: string
+  edition?: Edition
+}
+
+export type DescriptorProtoExtensionRange = {
+  start?: number
+  end?: number
+  options?: ExtensionRangeOptions
+}
+
+export type DescriptorProtoReservedRange = {
+  start?: number
+  end?: number
+}
+
+export type DescriptorProto = {
+  name?: string
+  field?: FieldDescriptorProto[]
+  extension?: FieldDescriptorProto[]
+  nestedType?: DescriptorProto[]
+  enumType?: EnumDescriptorProto[]
+  extensionRange?: DescriptorProtoExtensionRange[]
+  oneofDecl?: OneofDescriptorProto[]
+  options?: MessageOptions
+  reservedRange?: DescriptorProtoReservedRange[]
+  reservedName?: string[]
+}
+
+export type ExtensionRangeOptionsDeclaration = {
+  number?: number
+  fullName?: string
+  type?: string
+  reserved?: boolean
+  repeated?: boolean
+}
+
+export type ExtensionRangeOptions = {
+  uninterpretedOption?: UninterpretedOption[]
+  declaration?: ExtensionRangeOptionsDeclaration[]
+  features?: FeatureSet
+  verification?: ExtensionRangeOptionsVerificationState
+}
+
+export type FieldDescriptorProto = {
+  name?: string
+  number?: number
+  label?: FieldDescriptorProtoLabel
+  type?: FieldDescriptorProtoType
+  typeName?: string
+  extendee?: string
+  defaultValue?: string
+  oneofIndex?: number
+  jsonName?: string
+  options?: FieldOptions
+  proto3Optional?: boolean
+}
+
+export type OneofDescriptorProto = {
+  name?: string
+  options?: OneofOptions
+}
+
+export type EnumDescriptorProtoEnumReservedRange = {
+  start?: number
+  end?: number
+}
+
+export type EnumDescriptorProto = {
+  name?: string
+  value?: EnumValueDescriptorProto[]
+  options?: EnumOptions
+  reservedRange?: EnumDescriptorProtoEnumReservedRange[]
+  reservedName?: string[]
+}
+
+export type EnumValueDescriptorProto = {
+  name?: string
+  number?: number
+  options?: EnumValueOptions
+}
+
+export type ServiceDescriptorProto = {
+  name?: string
+  method?: MethodDescriptorProto[]
+  options?: ServiceOptions
+}
+
+export type MethodDescriptorProto = {
+  name?: string
+  inputType?: string
+  outputType?: string
+  options?: MethodOptions
+  clientStreaming?: boolean
+  serverStreaming?: boolean
+}
+
+export type FileOptions = {
+  javaPackage?: string
+  javaOuterClassname?: string
+  javaMultipleFiles?: boolean
+  javaGenerateEqualsAndHash?: boolean
+  javaStringCheckUtf8?: boolean
+  optimizeFor?: FileOptionsOptimizeMode
+  goPackage?: string
+  ccGenericServices?: boolean
+  javaGenericServices?: boolean
+  pyGenericServices?: boolean
+  phpGenericServices?: boolean
+  deprecated?: boolean
+  ccEnableArenas?: boolean
+  objcClassPrefix?: string
+  csharpNamespace?: string
+  swiftPrefix?: string
+  phpClassPrefix?: string
+  phpNamespace?: string
+  phpMetadataNamespace?: string
+  rubyPackage?: string
+  features?: FeatureSet
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type MessageOptions = {
+  messageSetWireFormat?: boolean
+  noStandardDescriptorAccessor?: boolean
+  deprecated?: boolean
+  mapEntry?: boolean
+  deprecatedLegacyJsonFieldConflicts?: boolean
+  features?: FeatureSet
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type FieldOptionsEditionDefault = {
+  edition?: Edition
+  value?: string
+}
+
+export type FieldOptions = {
+  ctype?: FieldOptionsCType
+  packed?: boolean
+  jstype?: FieldOptionsJSType
+  lazy?: boolean
+  unverifiedLazy?: boolean
+  deprecated?: boolean
+  weak?: boolean
+  debugRedact?: boolean
+  retention?: FieldOptionsOptionRetention
+  targets?: FieldOptionsOptionTargetType[]
+  editionDefaults?: FieldOptionsEditionDefault[]
+  features?: FeatureSet
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type OneofOptions = {
+  features?: FeatureSet
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type EnumOptions = {
+  allowAlias?: boolean
+  deprecated?: boolean
+  deprecatedLegacyJsonFieldConflicts?: boolean
+  features?: FeatureSet
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type EnumValueOptions = {
+  deprecated?: boolean
+  features?: FeatureSet
+  debugRedact?: boolean
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type ServiceOptions = {
+  features?: FeatureSet
+  deprecated?: boolean
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type MethodOptions = {
+  deprecated?: boolean
+  idempotencyLevel?: MethodOptionsIdempotencyLevel
+  features?: FeatureSet
+  uninterpretedOption?: UninterpretedOption[]
+}
+
+export type UninterpretedOptionNamePart = {
+  namePart?: string
+  isExtension?: boolean
+}
+
+export type UninterpretedOption = {
+  name?: UninterpretedOptionNamePart[]
+  identifierValue?: string
+  positiveIntValue?: string
+  negativeIntValue?: string
+  doubleValue?: number
+  stringValue?: Uint8Array
+  aggregateValue?: string
+}
+
+export type FeatureSet = {
+  fieldPresence?: FeatureSetFieldPresence
+  enumType?: FeatureSetEnumType
+  repeatedFieldEncoding?: FeatureSetRepeatedFieldEncoding
+  utf8Validation?: FeatureSetUtf8Validation
+  messageEncoding?: FeatureSetMessageEncoding
+  jsonFormat?: FeatureSetJsonFormat
+}
+
+export type FeatureSetDefaultsFeatureSetEditionDefault = {
+  edition?: Edition
+  features?: FeatureSet
+}
+
+export type FeatureSetDefaults = {
+  defaults?: FeatureSetDefaultsFeatureSetEditionDefault[]
+  minimumEdition?: Edition
+  maximumEdition?: Edition
+}
+
+export type SourceCodeInfoLocation = {
+  path?: number[]
+  span?: number[]
+  leadingComments?: string
+  trailingComments?: string
+  leadingDetachedComments?: string[]
+}
+
+export type SourceCodeInfo = {
+  location?: SourceCodeInfoLocation[]
+}
+
+export type GeneratedCodeInfoAnnotation = {
+  path?: number[]
+  sourceFile?: string
+  begin?: number
+  end?: number
+  semantic?: GeneratedCodeInfoAnnotationSemantic
+}
+
+export type GeneratedCodeInfo = {
+  annotation?: GeneratedCodeInfoAnnotation[]
+}

--- a/src/gen/google/protobuf/duration.pb.ts
+++ b/src/gen/google/protobuf/duration.pb.ts
@@ -1,0 +1,9 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+export type Duration = {
+  seconds?: string
+  nanos?: number
+}

--- a/src/gen/google/protobuf/struct.pb.ts
+++ b/src/gen/google/protobuf/struct.pb.ts
@@ -1,0 +1,33 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+type Absent<T, K extends keyof T> = { [k in Exclude<keyof T, K>]?: undefined };
+type OneOf<T> =
+  | { [k in keyof T]?: undefined }
+  | (
+    keyof T extends infer K ?
+      (K extends string & keyof T ? { [k in K]: T[K] } & Absent<T, K>
+        : never)
+    : never);
+
+export enum NullValue {
+  NULL_VALUE = "NULL_VALUE",
+}
+
+export type Struct = {
+  fields?: {[key: string]: Value}
+}
+
+
+type BaseValue = {
+}
+
+export type Value = BaseValue
+  & OneOf<{ nullValue: NullValue; numberValue: number; stringValue: string; boolValue: boolean; structValue: Struct; listValue: ListValue }>
+
+export type ListValue = {
+  values?: Value[]
+}

--- a/src/gen/protoc-gen-openapiv2/options/annotations.pb.ts
+++ b/src/gen/protoc-gen-openapiv2/options/annotations.pb.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/src/gen/protoc-gen-openapiv2/options/openapiv2.pb.ts
+++ b/src/gen/protoc-gen-openapiv2/options/openapiv2.pb.ts
@@ -1,0 +1,217 @@
+/* eslint-disable */
+// @ts-nocheck
+/*
+* This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
+*/
+
+import * as GoogleProtobufStruct from "../../google/protobuf/struct.pb"
+
+export enum Scheme {
+  UNKNOWN = "UNKNOWN",
+  HTTP = "HTTP",
+  HTTPS = "HTTPS",
+  WS = "WS",
+  WSS = "WSS",
+}
+
+export enum HeaderParameterType {
+  UNKNOWN = "UNKNOWN",
+  STRING = "STRING",
+  NUMBER = "NUMBER",
+  INTEGER = "INTEGER",
+  BOOLEAN = "BOOLEAN",
+}
+
+export enum JSONSchemaJSONSchemaSimpleTypes {
+  UNKNOWN = "UNKNOWN",
+  ARRAY = "ARRAY",
+  BOOLEAN = "BOOLEAN",
+  INTEGER = "INTEGER",
+  NULL = "NULL",
+  NUMBER = "NUMBER",
+  OBJECT = "OBJECT",
+  STRING = "STRING",
+}
+
+export enum SecuritySchemeType {
+  TYPE_INVALID = "TYPE_INVALID",
+  TYPE_BASIC = "TYPE_BASIC",
+  TYPE_API_KEY = "TYPE_API_KEY",
+  TYPE_OAUTH2 = "TYPE_OAUTH2",
+}
+
+export enum SecuritySchemeIn {
+  IN_INVALID = "IN_INVALID",
+  IN_QUERY = "IN_QUERY",
+  IN_HEADER = "IN_HEADER",
+}
+
+export enum SecuritySchemeFlow {
+  FLOW_INVALID = "FLOW_INVALID",
+  FLOW_IMPLICIT = "FLOW_IMPLICIT",
+  FLOW_PASSWORD = "FLOW_PASSWORD",
+  FLOW_APPLICATION = "FLOW_APPLICATION",
+  FLOW_ACCESS_CODE = "FLOW_ACCESS_CODE",
+}
+
+export type Swagger = {
+  swagger?: string
+  info?: Info
+  host?: string
+  basePath?: string
+  schemes?: Scheme[]
+  consumes?: string[]
+  produces?: string[]
+  responses?: {[key: string]: Response}
+  securityDefinitions?: SecurityDefinitions
+  security?: SecurityRequirement[]
+  tags?: Tag[]
+  externalDocs?: ExternalDocumentation
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+}
+
+export type Operation = {
+  tags?: string[]
+  summary?: string
+  description?: string
+  externalDocs?: ExternalDocumentation
+  operationId?: string
+  consumes?: string[]
+  produces?: string[]
+  responses?: {[key: string]: Response}
+  schemes?: Scheme[]
+  deprecated?: boolean
+  security?: SecurityRequirement[]
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+  parameters?: Parameters
+}
+
+export type Parameters = {
+  headers?: HeaderParameter[]
+}
+
+export type HeaderParameter = {
+  name?: string
+  description?: string
+  type?: HeaderParameterType
+  format?: string
+  required?: boolean
+}
+
+export type Header = {
+  description?: string
+  type?: string
+  format?: string
+  default?: string
+  pattern?: string
+}
+
+export type Response = {
+  description?: string
+  schema?: Schema
+  headers?: {[key: string]: Header}
+  examples?: {[key: string]: string}
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+}
+
+export type Info = {
+  title?: string
+  description?: string
+  termsOfService?: string
+  contact?: Contact
+  license?: License
+  version?: string
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+}
+
+export type Contact = {
+  name?: string
+  url?: string
+  email?: string
+}
+
+export type License = {
+  name?: string
+  url?: string
+}
+
+export type ExternalDocumentation = {
+  description?: string
+  url?: string
+}
+
+export type Schema = {
+  jsonSchema?: JSONSchema
+  discriminator?: string
+  readOnly?: boolean
+  externalDocs?: ExternalDocumentation
+  example?: string
+}
+
+export type JSONSchemaFieldConfiguration = {
+  pathParamName?: string
+}
+
+export type JSONSchema = {
+  ref?: string
+  title?: string
+  description?: string
+  default?: string
+  readOnly?: boolean
+  example?: string
+  multipleOf?: number
+  maximum?: number
+  exclusiveMaximum?: boolean
+  minimum?: number
+  exclusiveMinimum?: boolean
+  maxLength?: string
+  minLength?: string
+  pattern?: string
+  maxItems?: string
+  minItems?: string
+  uniqueItems?: boolean
+  maxProperties?: string
+  minProperties?: string
+  required?: string[]
+  array?: string[]
+  type?: JSONSchemaJSONSchemaSimpleTypes[]
+  format?: string
+  enum?: string[]
+  fieldConfiguration?: JSONSchemaFieldConfiguration
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+}
+
+export type Tag = {
+  name?: string
+  description?: string
+  externalDocs?: ExternalDocumentation
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+}
+
+export type SecurityDefinitions = {
+  security?: {[key: string]: SecurityScheme}
+}
+
+export type SecurityScheme = {
+  type?: SecuritySchemeType
+  description?: string
+  name?: string
+  in?: SecuritySchemeIn
+  flow?: SecuritySchemeFlow
+  authorizationUrl?: string
+  tokenUrl?: string
+  scopes?: Scopes
+  extensions?: {[key: string]: GoogleProtobufStruct.Value}
+}
+
+export type SecurityRequirementSecurityRequirementValue = {
+  scope?: string[]
+}
+
+export type SecurityRequirement = {
+  securityRequirement?: {[key: string]: SecurityRequirementSecurityRequirementValue}
+}
+
+export type Scopes = {
+  scope?: {[key: string]: string}
+}


### PR DESCRIPTION
This PR modifies the code generation process to depend on BSR registries rather than depending on protos directly in the same repo. This allows us to remove the protos files from this repo and simplify the overall `buf` workflow.
