### PR TITLE
Add explicit generation fields

### DIFF
--- a/docs/openapi/orchestration.swagger.json
+++ b/docs/openapi/orchestration.swagger.json
@@ -481,7 +481,23 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/StakingServicePerformWorkflowStepBody"
+              "type": "object",
+              "properties": {
+                "step": {
+                  "type": "integer",
+                  "format": "int32",
+                  "description": "The index of the step to be performed."
+                },
+                "data": {
+                  "type": "string",
+                  "description": "Transaction metadata. This is either the signed transaction or transaction hash depending on the workflow's broadcast method."
+                }
+              },
+              "description": "The request message for PerformWorkflowStep.",
+              "required": [
+                "step",
+                "data"
+              ]
             }
           }
         ],
@@ -728,25 +744,6 @@
       ],
       "default": "BALANCE_STATE_UNSPECIFIED",
       "description": "Represents the different states a stake account balance can have.\nUsed to check to see if stake is actively earning rewards or ready to be withdrawn.\n\n - BALANCE_STATE_UNSPECIFIED: The balance is not known.\n - BALANCE_STATE_INACTIVE: The balance is not actively staking.\n - BALANCE_STATE_ACTIVATING: The balance is in a warm up period and will activate in the next epoch.\n - BALANCE_STATE_ACTIVE: The balance is actively staking and earning rewards.\n - BALANCE_STATE_DEACTIVATING: The balance is in a cool down period and will be deactivated in the next epoch."
-    },
-    "StakingServicePerformWorkflowStepBody": {
-      "type": "object",
-      "properties": {
-        "step": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The index of the step to be performed."
-        },
-        "data": {
-          "type": "string",
-          "description": "Transaction metadata. This is either the signed transaction or transaction hash depending on the workflow's broadcast method."
-        }
-      },
-      "description": "The request message for PerformWorkflowStep.",
-      "required": [
-        "step",
-        "data"
-      ]
     },
     "WaitStepOutputWaitUnit": {
       "type": "string",

--- a/docs/openapi/rewards.swagger.json
+++ b/docs/openapi/rewards.swagger.json
@@ -409,7 +409,7 @@
         },
         "date": {
           "type": "string",
-          "description": "The date of the reward in format 'YYYY-MM-DD' in UTC.",
+          "title": "The date of the reward in format 'YYYY-MM-DD' in UTC.",
           "readOnly": true
         },
         "aggregationUnit": {
@@ -454,7 +454,7 @@
           "readOnly": true
         }
       },
-      "description": "Rewards earned within a particular period of time."
+      "title": "Rewards earned within a particular period of time."
     },
     "v1RewardRate": {
       "type": "object",
@@ -537,7 +537,7 @@
           "readOnly": true
         }
       },
-      "description": "The representation of a staking activity at a particular point in time."
+      "title": "The representation of a staking activity at a particular point in time."
     },
     "v1USDValue": {
       "type": "object",

--- a/protos/buf.gen.rewards.yaml
+++ b/protos/buf.gen.rewards.yaml
@@ -9,3 +9,8 @@ plugins:
     opt:
       - allow_merge=true
       - merge_file_name=rewards
+      - Mcoinbase/staking/rewards/v1/reward_service.proto=github.com/coinbase/staking-client-library-ts
+      - Mcoinbase/staking/rewards/v1/reward.proto=github.com/coinbase/staking-client-library-ts
+      - Mcoinbase/staking/rewards/v1/stake.proto=github.com/coinbase/staking-client-library-ts
+      - Mcoinbase/staking/rewards/v1/common.proto=github.com/coinbase/staking-client-library-ts
+      - Mcoinbase/staking/rewards/v1/protocol.proto=github.com/coinbase/staking-client-library-ts


### PR DESCRIPTION
The previous generation relied on `go_package` fields in the `coinbase.staking.rewards` package, which we removed. This change ensures the generation still works.
