### PR TITLE
Prep 0.7.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coinbase/staking-client-library-ts",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coinbase/staking-client-library-ts",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethereumjs/tx": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/staking-client-library-ts",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Coinbase Staking API Typescript Library",
   "repository": "https://github.com/coinbase/staking-client-library-ts.git",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is a dummy PR to just bump a patch version to get a clean GH tag, release and npm pkg published. Previous PR to automate GH release process mistakenly published the npm pkg. I have since removed the 0.7.0 tags, release and npm version but the mainline build still fails at re-publishing the 0.7.0 npm pkg. This is to help get a clean start.