### PR TITLE
Client interface updates

### DIFF
--- a/examples/ethereum/create-and-process-workflow.ts
+++ b/examples/ethereum/create-and-process-workflow.ts
@@ -10,7 +10,7 @@ import { Workflow } from '../../src/gen/coinbase/staking/orchestration/v1/workfl
 import { calculateTimeDifference } from '../../src/utils/date';
 
 const walletPrivateKey: string = 'your-wallet-private-key'; // replace with your wallet's private key
-const stakerAddress: string = '0xdb816889F2a7362EF242E5a717dfD5B38Ae849FE'; // replace with your staker address
+const stakerAddress: string = 'your-wallet-address'; // replace with your staker address
 const amount: string = '123'; // replace with your amount
 const network: string = 'holesky'; // replace with your network
 

--- a/examples/ethereum/create-and-process-workflow.ts
+++ b/examples/ethereum/create-and-process-workflow.ts
@@ -32,16 +32,10 @@ async function stakePartialEth(): Promise<void> {
   let unsignedTx = '';
   let workflow: Workflow = {} as Workflow;
   let currentStepId: number | undefined;
-  let workflowId: string;
 
   try {
     // Create a new eth kiln stake workflow
     workflow = await client.Ethereum.stake(network, stakerAddress, amount);
-
-    workflowId = workflow.name?.split('/').pop() || '';
-    if (workflowId == null || workflowId === '') {
-      throw new Error('Unexpected workflow state. workflowId is null');
-    }
 
     currentStepId = workflow.currentStepId;
     if (currentStepId == null) {
@@ -64,7 +58,7 @@ async function stakePartialEth(): Promise<void> {
     // If the workflow is waiting for external broadcast, sign and broadcast the unsigned tx externally and return back the tx hash via the PerformWorkflowStep API.
     // Note: In this example, we just log this message as the wallet provider needs to implement this logic.
     try {
-      workflow = await client.getWorkflow(workflowId);
+      workflow = await client.getWorkflow(workflow.name!);
     } catch (error) {
       // TODO: add retry logic for network errors
       if (error instanceof Error) {

--- a/examples/solana/create-and-process-workflow.ts
+++ b/examples/solana/create-and-process-workflow.ts
@@ -32,16 +32,10 @@ async function stakeSolana(): Promise<void> {
   let unsignedTx = '';
   let workflow: Workflow = {} as Workflow;
   let currentStepId: number | undefined;
-  let workflowId: string;
 
   try {
     // Create a new solana stake workflow
     workflow = await client.Solana.stake(network, walletAddress, amount);
-
-    workflowId = workflow.name?.split('/').pop() || '';
-    if (workflowId == null || workflowId === '') {
-      throw new Error('Unexpected workflow state. workflowId is null');
-    }
 
     currentStepId = workflow.currentStepId;
     if (currentStepId == null) {
@@ -67,7 +61,7 @@ async function stakeSolana(): Promise<void> {
     // If the workflow is waiting for external broadcast, sign and broadcast the unsigned tx externally and return back the tx hash via the PerformWorkflowStep API.
     // Note: In this example, we just log this message as the wallet provider needs to implement this logic.
     try {
-      workflow = await client.getWorkflow(workflowId);
+      workflow = await client.getWorkflow(workflow.name!);
     } catch (error) {
       // TODO: add retry logic for network errors
       if (error instanceof Error) {

--- a/examples/solana/create-and-process-workflow.ts
+++ b/examples/solana/create-and-process-workflow.ts
@@ -10,9 +10,9 @@ import { Workflow } from '../../src/gen/coinbase/staking/orchestration/v1/workfl
 import { calculateTimeDifference } from '../../src/utils/date';
 
 const walletPrivateKey: string = 'your-wallet-private-key'; // replace with your wallet's private key
-const walletAddress: string = ''; // replace with your wallet address
+const walletAddress: string = 'your-wallet-address'; // replace with your wallet address
 const amount: string = '100000000'; // replace with your amount. For solana it should be >= 0.1 SOL
-const network: string = 'mainnet'; // replace with your network
+const network: string = 'devnet'; // replace with your network
 
 // Set your api key name and private key here. Get your keys from here: https://portal.cdp.coinbase.com/access/api
 const apiKeyName: string = 'your-api-key-name';

--- a/src/client/staking-client.ts
+++ b/src/client/staking-client.ts
@@ -186,8 +186,8 @@ export class StakingClient {
   }
 
   // Get a workflow given workflow id.
-  async getWorkflow(workflow_name: string): Promise<Workflow> {
-    const path: string = `/v1/${workflow_name}`;
+  async getWorkflow(workflowName: string): Promise<Workflow> {
+    const path: string = `/v1/${workflowName}`;
     const method: string = 'GET';
     const url: string = this.baseURL + '/orchestration';
 
@@ -202,7 +202,7 @@ export class StakingClient {
     );
 
     const req: GetWorkflowRequest = {
-      name: workflow_name,
+      name: workflowName,
     };
 
     return StakingService.GetWorkflow(req, initReq);
@@ -210,11 +210,11 @@ export class StakingClient {
 
   // Return back a signed tx or a broadcasted tx hash for a given workflow and step number.
   async performWorkflowStep(
-    workflow_name: string,
+    workflowName: string,
     stepIndex: number,
     data: string,
   ): Promise<Workflow> {
-    const name: string = `${parent}/${workflow_name}`;
+    const name: string = `${parent}/${workflowName}`;
     const path: string = `/v1/${name}/step`;
     const method: string = 'POST';
     const url: string = this.baseURL + '/orchestration';

--- a/src/client/staking-client.ts
+++ b/src/client/staking-client.ts
@@ -186,9 +186,8 @@ export class StakingClient {
   }
 
   // Get a workflow given workflow id.
-  async getWorkflow(workflowId: string): Promise<Workflow> {
-    const name: string = `workflows/${workflowId}`;
-    const path: string = `/v1/${name}`;
+  async getWorkflow(workflow_name: string): Promise<Workflow> {
+    const path: string = `/v1/${workflow_name}`;
     const method: string = 'GET';
     const url: string = this.baseURL + '/orchestration';
 
@@ -203,7 +202,7 @@ export class StakingClient {
     );
 
     const req: GetWorkflowRequest = {
-      name: name,
+      name: workflow_name,
     };
 
     return StakingService.GetWorkflow(req, initReq);
@@ -211,11 +210,11 @@ export class StakingClient {
 
   // Return back a signed tx or a broadcasted tx hash for a given workflow and step number.
   async performWorkflowStep(
-    workflowId: string,
+    workflow_name: string,
     stepIndex: number,
     data: string,
   ): Promise<Workflow> {
-    const name: string = `${parent}/workflows/${workflowId}`;
+    const name: string = `${parent}/${workflow_name}`;
     const path: string = `/v1/${name}/step`;
     const method: string = 'POST';
     const url: string = this.baseURL + '/orchestration';


### PR DESCRIPTION
## Description Of Change

The ts client currently has an interface where for APIs like `getWorkflow` and `performWorkflowStep` it expects the user to pass a workflow id. This forces a user to parse out the workflow.name and get it from there. Instead what's easier is, the client interface takes the workflow name as input. One less thing the caller needs to worry about.

## Testing Procedure

<!-- Describe how this change has been verified. Either via new automated tests or manual testing -->

Ran `ts-node examples/solana/create-and-process-workflow.ts` with appropriate input, to verify if all works.