### PR TITLE
Expose helper functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coinbase/staking-client-library-ts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coinbase/staking-client-library-ts",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethereumjs/tx": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/staking-client-library-ts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Coinbase Staking API Typescript Library",
   "repository": "https://github.com/coinbase/staking-client-library-ts.git",
   "license": "Apache-2.0",
@@ -10,8 +10,8 @@
     "clean-gen": "rm -rf src/gen/*",
     "build": "npm run clean && tsc",
     "prepare": "npm run build",
-    "lint": "eslint . --ext .ts --ignore-pattern '/dist/*/*' --ignore-pattern '/src/gen/*/*'",
-    "lint-fix": "eslint . --ext .ts --fix --ignore-pattern '/dist/*/*' --ignore-pattern '/src/gen/*/*'"
+    "lint": "eslint . --ext .ts --ignore-pattern 'dist/**/*' --ignore-pattern 'src/gen/**/*'",
+    "lint-fix": "eslint . --ext .ts --fix --ignore-pattern 'dist/**/*' --ignore-pattern 'src/gen/**/*'"
   },
   "publishConfig": {
     "access": "public",

--- a/src/client/staking-client.ts
+++ b/src/client/staking-client.ts
@@ -337,6 +337,26 @@ export function isWaitStepOutput(
   return (step as WorkflowStep).waitStepOutput !== undefined;
 }
 
+export function getUnsignedTx(workflow: Workflow): string {
+  if (workflow.steps === undefined) {
+    throw new Error('No steps found in workflow');
+  }
+
+  if (workflow.currentStepId === undefined) {
+    throw new Error('No current step found in workflow');
+  }
+
+  if (workflow.steps[workflow.currentStepId].txStepOutput === undefined) {
+    throw new Error(
+      `No txStepOutput found in workflow step ${workflow.currentStepId}`,
+    );
+  }
+
+  return <string>(
+    workflow.steps[workflow.currentStepId].txStepOutput?.unsignedTx
+  );
+}
+
 async function getAuthDetails(
   url: string,
   path: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,13 @@ import * as Utils from './utils/date';
 
 export { Utils };
 
-export { StakingClient } from './client/staking-client';
+export {
+  StakingClient,
+  workflowHasFinished,
+  workflowWaitingForExternalBroadcast,
+  isTxStepOutput,
+  isWaitStepOutput,
+  getUnsignedTx,
+} from './client/staking-client';
+
+export { TxSignerFactory } from './signers';


### PR DESCRIPTION
## Description Of Change

As I work on enhancing our [QuickStart guide](https://docs.cdp.coinbase.com/staking/docs/welcome) to add a concrete example to do a e2e stake tx, I realized that having helper functions around reading unsigned txs given a workflow and then ability to sign unsigned txs given wallet's private key would be very helpful.

## Testing Procedure

Created a demo app to import the newly exported functions and get a signed staking tx. This is the example that will go into our Quickstart guide.

```
import { StakingClient, TxSignerFactory, getUnsignedTx } from '@coinbase/staking-client-library-ts';

// Set your api key name and private key here. Get your keys from here: https://portal.cdp.coinbase.com/access/api
const apiKeyName: string = 'YOUR_API_KEY_NAME';
const apiPrivateKey: string = 'YOUR_API_PRIVATE_KEY';

// Set your wallet details
const walletAddress: string = 'YOUR_WALLET_ADDRESS';
const walletPrivateKey: string = 'YOUR_WALLET_PRIVATE_KEY';

const client = new StakingClient(apiKeyName, apiPrivateKey);

async function stake() {
    // Step 1 - Get an unsigned tx corresponding to a
    // stake of 11 wei ETH from your wallet on network Holesky.
    let workflow = await client.Ethereum.stake('holesky', walletAddress, '11');
    let unsignedTx = getUnsignedTx(workflow);
    console.log('Unsigned tx %s', unsignedTx);

    // Step 2 - Sign the unsigned tx with your wallet's private key.
    // Note: In production, this part would be performed via a wallet-sdk of your choice.
    const signer = TxSignerFactory.getSigner('ethereum');
    const signedTx = await signer.signTransaction(walletPrivateKey, unsignedTx);
    console.log('Signed tx %s', signedTx);

    console.log('You can use this UI https://holesky.etherscan.io/pushTx or ' +
    'APIs you are familiar with to help broadcast the signed tx on Holesky.');
}

stake().catch((error) => {
    console.error(error);
});
```
