### PR TITLE
Fix workflow name for PerformWorkflowStep API

### DIFF
--- a/src/client/staking-client.ts
+++ b/src/client/staking-client.ts
@@ -214,8 +214,7 @@ export class StakingClient {
     stepIndex: number,
     data: string,
   ): Promise<Workflow> {
-    const name: string = `${parent}/${workflowName}`;
-    const path: string = `/v1/${name}/step`;
+    const path: string = `/v1/${workflowName}/step`;
     const method: string = 'POST';
     const url: string = this.baseURL + '/orchestration';
 
@@ -230,7 +229,7 @@ export class StakingClient {
     );
 
     const req: PerformWorkflowStepRequest = {
-      name: name,
+      name: workflowName,
       step: stepIndex,
       data,
     };


### PR DESCRIPTION
## Description Of Change

This PR helps fix the workflow name being set while calling the `PerformWorkflowStep` API. This is a remnant from the time we had workflow parent.

## Testing Procedure

<!-- Describe how this change has been verified. Either via new automated tests or manual testing -->
